### PR TITLE
Make XMPP audio/video calls possible

### DIFF
--- a/conf/metronome.cfg.lua
+++ b/conf/metronome.cfg.lua
@@ -1,0 +1,50 @@
+external_services = {
+    ["__DOMAIN__"] = {
+        [1] = {
+            port = "__STANDARD_PORT__",
+            transport = "udp",
+            type = "stun"
+        },
+
+        [2] = {
+            port = "__STANDARD_PORT__",
+            transport = "tcp",
+            type = "stun"
+        },
+
+        [3] = {
+            port = "__TLS_PORT__",
+            transport = "tcp",
+            type = "stuns"
+        },
+        [4] = {
+            port = "__STANDARD_PORT__",
+            transport = "tcp",
+            type = "turn",
+            turn_secret = "__TURNPWD__",
+            turn_ttl = 300
+        },
+
+        [5] = {
+            port = "__STANDARD_PORT__",
+            transport = "udp",
+            type = "turn",
+            turn_secret = "__TURNPWD__",
+            turn_ttl = 7200
+        },
+
+        [6] = {
+            port = "__TLS_PORT__",
+            transport = "tcp",
+            type = "turns",
+            turn_secret = "__TURNPWD__",
+            turn_ttl = 7200
+        }
+    }
+};
+
+jingle_nodes_turn_credentials = true;
+jingle_nodes_turn_secret = "__TURNPWD__";
+jingle_nodes_turn_credentials_ttl = 86400;
+jingle_nodes_restricted = false;
+

--- a/conf/metronome.cfg.lua
+++ b/conf/metronome.cfg.lua
@@ -1,3 +1,9 @@
+-- XXX modules that need to be enabled in main config file.
+--modules_enabled = {
+--	"extdisco";
+--	"jingle_nodes";
+--};
+
 external_services = {
     ["__DOMAIN__"] = {
         [1] = {

--- a/conf/metronome.cfg.lua
+++ b/conf/metronome.cfg.lua
@@ -1,9 +1,3 @@
--- XXX modules that need to be enabled in main config file.
---modules_enabled = {
---	"extdisco";
---	"jingle_nodes";
---};
-
 external_services = {
     ["__DOMAIN__"] = {
         [1] = {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,6 +7,8 @@
 # dependencies used by the app
 pkg_dependencies="sqlite3 libsqlite3-dev coturn acl"
 
+metronome_snippet_path="/etc/metronome/conf.d/coturn.cfg.lua"
+
 #=================================================
 # PERSONAL HELPERS
 #=================================================

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -13,6 +13,25 @@ metronome_snippet_path="/etc/metronome/conf.d/coturn.cfg.lua"
 # PERSONAL HELPERS
 #=================================================
 
+ynh_metronome_ensure_module_is_enabled() {
+	module=${1:-admin_telnet}
+	if ! _metronome_modules_list | grep -qE "^${module}$" ; then
+		_metronome_module_add ${module}
+	fi
+}
+
+_metronome_modules_list() {
+	grep -Ev '^\s*--' /etc/metronome/metronome.cfg.lua \
+	 | sed -n '/^modules_enabled = {$/,/^\s*};$/p' \
+	 | grep '\s*"' | sed -r 's/^\s*"([^"]+)";.*/\1/'
+}
+
+_metronome_module_add() {
+	module=${1:-admin_telnet}
+	echo "Inserting module ${module}"
+	sed -i '/^modules_enabled = {/a \	\	"'${module}'"; -- XXX module added by coturn_ynh' /etc/metronome/metronome.cfg.lua
+}
+
 #=================================================
 # EXPERIMENTAL HELPERS
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -184,10 +184,9 @@ ynh_print_OFF
 ynh_replace_string --target_file="$metronome_snippet_path" --match_string=__TURNPWD__ --replace_string=$turnserver_pwd
 ynh_print_ON
 
-# TODO make sure the two following modules are enabled in metronome's main config
-#  "extdisco";
-#  "jingle_nodes";
-
+# Make sure the two following modules are enabled in metronome's main config
+ynh_metronome_ensure_module_is_enabled extdisco
+ynh_metronome_ensure_module_is_enabled jingle_nodes
 
 ynh_systemd_action --action="reload" --service_name="metronome"
 

--- a/scripts/install
+++ b/scripts/install
@@ -59,15 +59,20 @@ fi
 ynh_script_progression --message="Finding an available port..." --weight=3
 
 # Find an available port
+turnserver_standard_port=$(ynh_find_port --port=3478)
 turnserver_tls_port=$(ynh_find_port --port=5349)
 turnserver_alt_tls_port=$(ynh_find_port --port=$((turnserver_tls_port+1)))
 cli_port=$(ynh_find_port --port=5766)
 
+# TODO also reserve UDP Port range 49152:65535
+
 # Open the port
+ynh_exec_warn_less yunohost firewall allow Both $turnserver_standard_port
 ynh_exec_warn_less yunohost firewall allow Both $turnserver_tls_port
 ynh_exec_warn_less yunohost firewall allow Both $turnserver_alt_tls_port
 
 # Store opened ports
+ynh_app_setting_set --app=$app --key=turnserver_standard_port --value=$turnserver_standard_port
 ynh_app_setting_set --app=$app --key=turnserver_tls_port --value=$turnserver_tls_port
 ynh_app_setting_set --app=$app --key=turnserver_alt_tls_port --value=$turnserver_alt_tls_port
 ynh_app_setting_set --app=$app --key=cli_port --value=$cli_port
@@ -163,6 +168,27 @@ ynh_replace_string --match_string="__DATA_PATH__" --replace_string=$data_path --
 ynh_script_progression --message="Configuring log rotation..." --weight=1
 
 ynh_use_logrotate --logfile "/var/log/$app"
+
+#=================================================
+# ADD METRONOME CONFIGURATION
+#=================================================
+
+#ynh_add_config --template="metronome.cfg.lua" --destination="$metronome_snippet_path"
+cp ../conf/metronome.cfg.lua "$metronome_snippet_path"
+ynh_replace_string --target_file="$metronome_snippet_path" --match_string=__APP__ --replace_string=$app
+ynh_replace_string --target_file="$metronome_snippet_path" --match_string=__DOMAIN__ --replace_string=$domain
+ynh_replace_string --target_file="$metronome_snippet_path" --match_string=__STANDARD_PORT__ --replace_string=$turnserver_standard_port
+ynh_replace_string --target_file="$metronome_snippet_path" --match_string=__TLS_PORT__ --replace_string=$turnserver_tls_port
+ynh_print_OFF
+ynh_replace_string --target_file="$metronome_snippet_path" --match_string=__TURNPWD__ --replace_string=$turnserver_pwd
+ynh_print_ON
+
+# TODO make sure the two following modules are enabled in metronome's main config
+#  "extdisco";
+#  "jingle_nodes";
+
+
+ynh_systemd_action --action="reload" --service_name="metronome"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/install
+++ b/scripts/install
@@ -64,7 +64,8 @@ turnserver_tls_port=$(ynh_find_port --port=5349)
 turnserver_alt_tls_port=$(ynh_find_port --port=$((turnserver_tls_port+1)))
 cli_port=$(ynh_find_port --port=5766)
 
-# TODO also reserve UDP Port range 49152:65535
+# Reserve UDP Port range 49152:65535
+ynh_exec_warn_less yunohost firewall allow UDP -4 49152:65535 # XXX hard-coded values
 
 # Open the port
 ynh_exec_warn_less yunohost firewall allow Both $turnserver_standard_port

--- a/scripts/remove
+++ b/scripts/remove
@@ -115,7 +115,8 @@ then
     ynh_exec_warn_less yunohost firewall disallow Both $turnserver_alt_tls_port
 fi
 
-# TODO also release UDP port range 49152:65535
+# Release UDP port range 49152:65535
+ynh_exec_warn_less yunohost firewall disallow UDP -4 49152:65535 # XXX hard-coded values
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/remove
+++ b/scripts/remove
@@ -71,6 +71,10 @@ ynh_remove_logrotate
 #=================================================
 
 ynh_secure_remove --file="$metronome_snippet_path"
+
+# Disable modules
+sed -i '/ -- XXX module added by coturn_ynh/d' /etc/metronome/metronome.cfg.lua
+
 ynh_systemd_action --action="reload" --service_name="metronome"
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -17,6 +17,7 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
+turnserver_standard_port=$(ynh_app_setting_get --app=$app --key=turnserver_standard_port)
 turnserver_tls_port=$(ynh_app_setting_get --app=$app --key=turnserver_tls_port)
 turnserver_alt_tls_port=$(ynh_app_setting_get --app=$app --key=turnserver_alt_tls_port)
 
@@ -66,6 +67,13 @@ ynh_script_progression --message="Removing logrotate configuration..." --weight=
 ynh_remove_logrotate
 
 #=================================================
+# REMOVE METRONOME CONFIGURATION
+#=================================================
+
+ynh_secure_remove --file="$metronome_snippet_path"
+ynh_systemd_action --action="reload" --service_name="metronome"
+
+#=================================================
 # REMOVE SCRIPT
 #=================================================
 
@@ -89,6 +97,12 @@ ynh_secure_remove --file=/var/log/$app
 # CLOSE PORTS
 #=================================================
 
+if yunohost firewall list | grep -q "\- $turnserver_standard_port$"
+then
+    ynh_script_progression --message="Closing port $turnserver_standard_port..." --weight=1
+    ynh_exec_warn_less yunohost firewall disallow Both $turnserver_standard_port
+fi
+
 if yunohost firewall list | grep -q "\- $turnserver_tls_port$"
 then
     ynh_script_progression --message="Closing port $turnserver_tls_port..." --weight=1
@@ -100,6 +114,8 @@ then
     ynh_script_progression --message="Closing port $turnserver_alt_tls_port..." --weight=1
     ynh_exec_warn_less yunohost firewall disallow Both $turnserver_alt_tls_port
 fi
+
+# TODO also release UDP port range 49152:65535
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION
This PR takes care of configuring metronome in order to make audio/video calls with XMPP.
It mainly does this:
- insert 2 modules in */etc/metronome/metronome.cfg.lua*
- add new file */etc/metronome/conf.d/coturn.cfg.lua*

It has been tested in a VM running yunohost "dev" branch.

How to test (the hard way)
- install the coturn app from this repository
   ```yunohost app install https://github.com/glougloumoute/coturn_ynh-1.git```
- create 2 yunohost accounts
- use these accounts with an XMPP compatible app (Conversations on Android) on 2 different devices using 2 different internet connections
- try to make an audio/video call


Some things that should be improved (maybe later):
- improve UDP port-range reservation in install script (check if ports are available before configuring firewall)
- make a separate PR to have modules "jingle_nodes" and "extdisco" enabled by default in yunohost