### PR TITLE
Udp 443

### DIFF
--- a/conf/nginx_coturn.conf
+++ b/conf/nginx_coturn.conf
@@ -1,0 +1,13 @@
+stream {
+
+    upstream turn_backend {
+        server __PUBLIC_IP4__:__PORT_TURNSERVER_TLS__;
+    }
+
+    server {
+        listen 443 udp;
+        listen [::]:443 udp;
+        proxy_pass turn_backend;
+        ssl_preread off;
+  }
+}

--- a/conf/turnserver.conf
+++ b/conf/turnserver.conf
@@ -643,6 +643,19 @@ no-multicast-peers
 # Examples:
 # denied-peer-ip=83.166.64.0-83.166.95.255
 # allowed-peer-ip=83.166.68.45
+denied-peer-ip=10.0.0.0-10.255.255.255
+denied-peer-ip=100.64.0.0-100.127.255.255
+denied-peer-ip=127.0.0.0-127.255.255.255
+denied-peer-ip=169.254.0.0-169.254.255.255
+denied-peer-ip=172.16.0.0-172.31.255.255
+denied-peer-ip=192.0.0.0-192.0.0.255
+denied-peer-ip=192.0.2.0-192.0.2.255
+denied-peer-ip=192.88.99.0-192.88.99.255
+denied-peer-ip=192.168.0.0-192.168.255.255
+denied-peer-ip=198.18.0.0-198.19.255.255
+denied-peer-ip=198.51.100.0-198.51.100.255
+denied-peer-ip=203.0.113.0-203.0.113.255
+denied-peer-ip=240.0.0.0-255.255.255.255
 
 # File name to store the pid of the process.
 # Default is /var/run/turnserver.pid (if superuser account is used) or

--- a/scripts/backup
+++ b/scripts/backup
@@ -10,6 +10,7 @@ ynh_print_info "Declaring files to be backed up..."
 #=================================================
 
 ynh_backup "/etc/turnserver.conf"
+ynh_backup "/etc/nginx/modules-enabled/$app.conf"
 
 #=================================================
 # BACKUP THE COTURN DATAPATH

--- a/scripts/install
+++ b/scripts/install
@@ -68,6 +68,10 @@ fi
 
 ynh_store_file_checksum "$coturn_config_path"
 
+# UDP 443
+ynh_config_add --template="nginx_coturn.conf" --destination="/etc/nginx/modules-enabled/$app.conf"
+
+
 #=================================================
 # ADD SCRIPT FOR COTURN CRON
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -15,6 +15,7 @@ fi
 ynh_config_remove_systemd
 
 ynh_safe_rm "/etc/turnserver.conf"
+ynh_safe_rm "/etc/nginx/modules-enabled/$app.conf"
 
 ynh_config_remove_logrotate
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -9,6 +9,7 @@ source /usr/share/yunohost/helpers
 ynh_script_progression "Restoring Coturn configuration..."
 
 ynh_restore "/etc/turnserver.conf"
+ynh_restore "/etc/nginx/modules-enabled/$app.conf"
 
 #=================================================
 # RESTORE THE COTURN DATAPATH

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -52,6 +52,9 @@ fi
 
 ynh_store_file_checksum "$coturn_config_path"
 
+# UDP 443
+ynh_config_add --template="nginx_coturn.conf" --destination="/etc/nginx/modules-enabled/$app.conf"
+
 #=================================================
 # ADD SCRIPT FOR COTURN CRON
 #=================================================


### PR DESCRIPTION
## Problem

For compatibility reasons it is highly recommended to run coturn onto 443 port

## Solution

As 443 TCP is used by nginx, this pr suggest to make coturn available thanks to 443 UDP via nginx stream feature.

Note, we probably could use iptables to redirect the port instead ????

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
