### PR TITLE
Uncomment use-auth-secret in turnserver.conf

### DIFF
--- a/conf/turnserver.conf
+++ b/conf/turnserver.conf
@@ -233,7 +233,7 @@ max-port=65535
 # Use either lt-cred-mech or use-auth-secret in the conf
 # to avoid any confusion.
 #
-#use-auth-secret
+use-auth-secret
 
 # 'Static' authentication secret value (a string) for TURN REST API only.
 # If not set, then the turn server


### PR DESCRIPTION
## Problem

I couldn't authentivate with coturn

## Solution

I uncommented "use-auth-secret" in turnserver.conf

I'm pretty sure I had to do this to be able to actually use this app, might be wrong though.

The documentation seems to suggest that either this or "lt-cred-mech" should be uncommented.

It also seems to be what synapse_ynh does with [its config](https://github.com/YunoHost-Apps/synapse_ynh/blob/master/conf/turnserver.conf)

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
